### PR TITLE
Fix rate limiter bug

### DIFF
--- a/RateLimiter/ConfigurationService.java
+++ b/RateLimiter/ConfigurationService.java
@@ -14,7 +14,8 @@ public class ConfigurationService {
         Map<String, Configuration> configMap = new HashMap<>();
         Gson gson = new Gson();
         
-        try (FileReader reader = new FileReader("RateLimiter\\config.json")) {
+        String configPath = java.nio.file.Paths.get("RateLimiter", "config.json").toString();
+        try (FileReader reader = new FileReader(configPath)) {
             JsonElement jsonElement = new JsonStreamParser(reader).next();
             if (jsonElement.isJsonArray()) {
                 for (JsonElement element : jsonElement.getAsJsonArray()) {

--- a/RateLimiter/RequestLog.java
+++ b/RateLimiter/RequestLog.java
@@ -11,9 +11,8 @@ public class RequestLog {
     }
 
     public void addLog(long lastRequestTime, int requestCount) {
-        requestLog.putIfAbsent(lastRequestTime, requestCount);
-        requestCount += requestLog.get(lastRequestTime);
-        requestLog.put(lastRequestTime, requestCount);
+        int existingCount = requestLog.getOrDefault(lastRequestTime, 0);
+        requestLog.put(lastRequestTime, existingCount + requestCount);
     }
 
     public Map<Long,Integer> getRequestLog() {

--- a/RateLimiter/SlidingWindow.java
+++ b/RateLimiter/SlidingWindow.java
@@ -30,7 +30,7 @@ public class SlidingWindow implements IRateLimiter {
         for(Map.Entry<Long,Integer> entry : log.getRequestLog().entrySet()) {
             if(entry.getKey() >= startTime) {
                 totalRequests += entry.getValue();
-                if(totalRequests > config.getRateLimit()) {
+                if(totalRequests >= config.getRateLimit()) {
                     return false;
                 }
             }


### PR DESCRIPTION
## Summary
- read configuration using OS agnostic path
- increment request counters correctly
- prevent 4th request from being allowed

## Testing
- `java -jar lib/junit-platform-console-standalone-1.11.3.jar --class-path bin:lib/gson-2.11.0.jar --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_6845687b49848331b075da6fa35e14a3